### PR TITLE
CVE-2010-2227

### DIFF
--- a/cves/CVE-2010-2227.yml
+++ b/cves/CVE-2010-2227.yml
@@ -63,16 +63,23 @@ fixes_vcc_instructions: |
   Refer to our instructions on how to find a Git SHA from an SVN revision.
 fixes:
    - commit: 4faaca9353e5e3f963c7a674b3ac6a0bd1c3757e
-     note: SVN rev 959428, from the Tomcat website.
+     note: |
+      SVN rev 959428, from the Tomcat website. This fix removed hard coded buffer lengths, and added handling for null values.
    - commit:
      note:
 vccs:
   - commit:
-    note: SVN rev 299033, from the tomcat website. Commit id was not found in the git logs
+    note: |
+      SVN rev 299033, from the tomcat website. Commit id was not found in the git logs. 
+      Added in the hard coded buffer to the input filter.
   - commit:
-    note: SVN rev 300442, from the tomcate website. Commit id was not found in the git logs
+    note: |
+      SVN rev 300442, from the tomcate website. Commit id was not found in the git logs.
+      Added the http apr processor, which included a hard coded buffer size and a lack of null handling.
   - commit:
-    note: SVN rev 296287, from the tomcat website. Commit id was not found in the git logs
+    note: |
+      SVN rev 296287, from the tomcat website. Commit id was not found in the git logs.
+      Added the http11 processor, which included a hard coded buffer size and a lack of null handling.
 
 incomplete_fix_instructions: |
   Did the above "fixes" actually fix the vulnerability?
@@ -90,7 +97,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 7
 
 unit_tested:
   question: |
@@ -153,7 +160,7 @@ interesting_commits:
       note: |
         SVN rev 802162. This commit shows that while moving up in the versions this vunerability still existed and would not be found for
         around a year from this commit. This section of code had not been touched since the vunerability was created, so this was the first
-        time since its creation that a developer could have seen the innapro
+        time since its creation that a developer could have seen the innapropriate behavior and applied a fix.
     - commit:
       note:
 

--- a/cves/CVE-2010-2227.yml
+++ b/cves/CVE-2010-2227.yml
@@ -67,11 +67,11 @@ fixes:
    - commit:
      note:
 vccs:
-  - commit: 229033
+  - commit:
     note: SVN rev 299033, from the tomcat website. Commit id was not found in the git logs
-  - commit: 300442
+  - commit:
     note: SVN rev 300442, from the tomcate website. Commit id was not found in the git logs
-  - commit: 296287
+  - commit:
     note: SVN rev 296287, from the tomcat website. Commit id was not found in the git logs
 
 incomplete_fix_instructions: |

--- a/cves/CVE-2010-2227.yml
+++ b/cves/CVE-2010-2227.yml
@@ -10,7 +10,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE:
+CWE: CWE-184
 
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
@@ -18,13 +18,13 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 
 reported_instructions: |
   Was there a date that this vulnerability was reported to the team? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE data.
   Please enter your date in YYYY-MM-DD format.
-reported:
+reported: 2010-06-09
 
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
@@ -43,7 +43,10 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
+  This vunerability was the checks for a Transfer Encoding Header, which is used when transfering between nodes, did not properly
+  handle invalid headers, which allowed for denial of service attacks, or for the possiblity of obtaining sensitive information by 
+  buffer overflow.
 
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
@@ -51,7 +54,7 @@ bounty_instructions: |
   was wrong. Otherwise, leave it blank.
 bounty:
   amt:
-  announced: 2010-07-13
+  announced:
   url:
 bugs: []
 fixes_vcc_instructions: |
@@ -64,8 +67,8 @@ fixes:
    - commit:
      note:
 vccs:
-  - commit:
-    note:
+  - commit: 
+    note: SVN rev 299033, from the tomcat website.
   - commit:
     note:
 
@@ -99,9 +102,11 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
     Must be just "true" or "false".
-  answer:
-  code:
-  fix:
+  answer: |
+    No unit tests exist as a part of this commit nor are there any unit tests that deal with this vunerability.
+    The fix did not involve any unit tests, and no unit tests seemed to exist for this vunerability.
+  code: false
+  fix: false
 
 discovered:
   question: |
@@ -116,8 +121,9 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then you
     may leave the entries blank except for "answer", BUT please write down
     where you looked in "answer".
-  answer:
-  date:
+  answer: |
+    Credited to Steve Jones, but it is not shown how or why he found it.
+  date: 2010-06-09
   automated:
   contest:
 
@@ -128,8 +134,8 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
     Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer:
-  name:
+  answer: Saw it in the path to the file, the names of the classes, as well as in commit messages.
+  name: HTTP11 Connecters
 
 interesting_commits:
   question: |
@@ -141,8 +147,11 @@ interesting_commits:
     section by explaining what happened between the VCCs and the fix.
   answer:
   commits:
-    - commit:
-      note:
+    - commit: 2ee172f418591edd61cfd3dc9676753b281d1fe2
+      note: |
+        SVN rev 802162. This commit shows that while moving up in the versions this vunerability still existed and would not be found for
+        around a year from this commit. This section of code had not been touched since the vunerability was created, so this was the first
+        time since its creation that a developer could have seen the innapro
     - commit:
       note:
 
@@ -171,8 +180,9 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: |
+      This system trusted that inputs would only ever be a certain length as well as that inputs will not be null.
   security_by_obscurity:
     applies:
     note:
@@ -202,4 +212,10 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    The mistakes that occurred here were coding mistakes. The original mistake was that the error handling
+    that was created for the transfer encoding headers was incomplete, and could be abused in order to cause
+    either a denial of service or a buffer overflow. The fix to this looks proper as it made sure that invalid values
+    could not exploit the system as well, as well as making sure that buffers were not set to hard coded values, but isntead
+    were dynamic. This bug seems to be a result of a shortsighted first attempt at these handlers that included hard coded 
+    values that were meant to be replaced but never were. 

--- a/cves/CVE-2010-2227.yml
+++ b/cves/CVE-2010-2227.yml
@@ -67,10 +67,12 @@ fixes:
    - commit:
      note:
 vccs:
-  - commit: 
-    note: SVN rev 299033, from the tomcat website.
-  - commit:
-    note:
+  - commit: 229033
+    note: SVN rev 299033, from the tomcat website. Commit id was not found in the git logs
+  - commit: 300442
+    note: SVN rev 300442, from the tomcate website. Commit id was not found in the git logs
+  - commit: 296287
+    note: SVN rev 296287, from the tomcat website. Commit id was not found in the git logs
 
 incomplete_fix_instructions: |
   Did the above "fixes" actually fix the vulnerability?


### PR DESCRIPTION
CVE-2010-2227 information, for the vcc the commits were old enough that I could not find the commit ids.