### PR TITLE
CVE-2016-3092

### DIFF
--- a/cves/CVE-2016-3092.yml
+++ b/cves/CVE-2016-3092.yml
@@ -10,7 +10,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE:
+CWE: "20"
 
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
@@ -18,19 +18,19 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 
 reported_instructions: |
   Was there a date that this vulnerability was reported to the team? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE data.
   Please enter your date in YYYY-MM-DD format.
-reported:
+reported: "2016-05-09"
 
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE data.
   Please enter your date in YYYY-MM-DD format.
-announced: 2016-07-04 
+announced: "2016-06-21"
 
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -43,7 +43,13 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
+  A denial of service vulnerability was found in the Apache Commons FileUpload
+  component by setting a long boundary string. This long string caused the
+  parser to take an exceptionally long time to process the string, increasing
+  CPU usage. An attacker could use this to consume all CPU resources on the
+  server. This vulnerability is technically a member of the Apache Commons and
+  not Apache Tomcat.
 
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
@@ -51,7 +57,7 @@ bounty_instructions: |
   was wrong. Otherwise, leave it blank.
 bounty:
   amt:
-  announced: 2016-07-04 
+  announced:
   url:
 bugs: []
 fixes_vcc_instructions: |
@@ -70,8 +76,8 @@ fixes:
    - commit:
      note:
 vccs:
-  - commit:
-    note:
+  - commit: f1911d8c5f0dc3774fe731ae27d4a9a9b39197c3
+    note: Contributer renamed fileupload, earliest instance of code in Tomcat
   - commit:
     note:
 
@@ -105,9 +111,9 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
     Must be just "true" or "false".
-  answer:
-  code:
-  fix:
+  answer: false
+  code: false
+  fix: false
 
 discovered:
   question: |
@@ -122,7 +128,7 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then you
     may leave the entries blank except for "answer", BUT please write down
     where you looked in "answer".
-  answer:
+  answer: 
   date:
   automated:
   contest:
@@ -134,8 +140,8 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
     Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer:
-  name:
+  answer: "The file in question is in tomcat/java/org/apache/tomcat/util/http"
+  name: "http"
 
 interesting_commits:
   question: |
@@ -145,7 +151,9 @@ interesting_commits:
     emerging themes?
     If there are no interesting commits, demonstrate that you completed this
     section by explaining what happened between the VCCs and the fix.
-  answer:
+  answer: |
+    Not particularly. The code the vulnerability is in is a dependency and
+    not the Tomcat project itself.
   commits:
     - commit:
       note:
@@ -208,4 +216,6 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    Input validation was improperly handled originally. Prior to the fix
+    boundary existence was checked, however the boundary being too long was not


### PR DESCRIPTION
Added information on CVE-2016-3092 which represented a vulnerability in the Apache Commons FileUpload dependency. The vulnerability allowed an attacker to set a long boundary string which would cause the FileUpload to use a significant amount more of CPU resources during parsing.